### PR TITLE
Fix deployment hiccups encountered during 3.17 QA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ kubeconfig
 gke_gcloud_auth_plugin_cache
 istio-*/
 .DS_Store
+.vscode/
 
 # Generated files
 gcp/configure/cert-manager-certificate-issuer.yaml

--- a/aws/configure/install-external-dns.sh
+++ b/aws/configure/install-external-dns.sh
@@ -8,8 +8,9 @@ source "$SCRIPT_DIR/../../utils/common.sh"
 
 #Add the Helm repo to your local machine so it can find the installation Helm chart, which enables automated installation:
 print_info "Adding the Helm repo for external-dns..."
-helm repo add external-dns https://kubernetes-sigs.github.io/external-dns/
-helm repo update
+helm repo add external-dns https://kubernetes-sigs.github.io/external-dns/ --force-update
+# Update only this repo — a full `helm repo update` fails if another repo (e.g. bitnami from Kafka) is unreachable.
+helm repo update external-dns
 
 # Substitute the values in the template file with the actual values:
 envsubst < $SCRIPT_DIR/external-dns-values.template.yaml > $SCRIPT_DIR/external-dns-values.yaml

--- a/aws/deploy/main.tf.template
+++ b/aws/deploy/main.tf.template
@@ -319,7 +319,7 @@ module "rds_main" {
   identifier = "${NAME}"
 
   engine               = "postgres"
-  engine_version       = "17.4"
+  engine_version       = "${RDS_POSTGRES_ENGINE_VERSION}"
   family               = "postgres17"
   major_engine_version = "17"
 

--- a/aws/rasa/assistant/values.template.yaml
+++ b/aws/rasa/assistant/values.template.yaml
@@ -14,7 +14,6 @@ rasa:
     environment: production
     enableApi: true
     credentials:
-      enabled: true
       socketio:
         bot_message_evt: bot_uttered
         metadata_key: customData
@@ -42,7 +41,6 @@ rasa:
           provider: openai
       # Configure the assistant to use our PostgreSQL instance as the Tracker Store, which records the assistant's conversations.
       tracker_store:
-        enabled: true
         type: sql
         dialect: postgresql
         url: ${DB_HOST}
@@ -52,7 +50,6 @@ rasa:
       # Configure the assistant to use Redis as the Rasa Lock Store.
       # This is needed when you have a high-load scenario that requires the Rasa server to be replicated across multiple instances. It ensures that even with multiple servers, the messages for each conversation are handled in the correct sequence without any loss or overlap.
       lock_store:
-        enabled: true
         type: concurrent_redis
         port: 6379
         host: ${REDIS_HOST}
@@ -61,7 +58,6 @@ rasa:
         key_prefix: ${NAME}
       # Configure the assistant to use the Kafka broker. This allows us to perform further processing on the messages, like using the Rasa Studio Conversation View or Rasa Pro Analytics.
       event_broker:
-        enabled: true
         type: kafka
         security_protocol: SASL_PLAINTEXT
         sasl_mechanism: PLAIN

--- a/aws/setup/environment-variables.sh
+++ b/aws/setup/environment-variables.sh
@@ -47,7 +47,10 @@ export DB_STUDIO_DATABASE="studio"
 export DB_STUDIO_USERNAME="studio"
 # The database name for Keycloak.
 export DB_KEYCLOAK_DATABASE="keycloak"
-# The version of PostgreSQL Container to use for applying some configuration to the database.
+# RDS PostgreSQL engine version (full minor, e.g. 17.10). Must exist in your region —
+# list with: aws rds describe-db-engine-versions --engine postgres --query "DBEngineVersions[?starts_with(EngineVersion, \`17\`)].EngineVersion" --output text
+export RDS_POSTGRES_ENGINE_VERSION="17.10"
+# The major version for the db-init Job postgres image tag (docker hub major tag).
 export PG_VERSION=17
 # The username for the ElastiCache Redis IAM role.
 export REDIS_USER="assistant"
@@ -96,6 +99,7 @@ echo "DB studio database:     $DB_STUDIO_DATABASE"
 echo "DB studio username:     $DB_STUDIO_USERNAME"
 echo "DB keycloak database:   $DB_KEYCLOAK_DATABASE"
 echo "Redis user:             $REDIS_USER"
+echo "RDS Postgres version:   $RDS_POSTGRES_ENGINE_VERSION"
 echo "PostgreSQL version:     $PG_VERSION"
 echo "--------------------------------"
 echo "If any of the above values are incorrect or blank, please update the file and re-run."

--- a/azure/rasa/assistant/setup-assistant.sh
+++ b/azure/rasa/assistant/setup-assistant.sh
@@ -15,7 +15,7 @@ rm -rf $SCRIPT_DIR/repos
 # This Helm chart contains instructions for setting up theRasa bot and Analytics components.
 print_info "Pulling Rasa Helm chart..."
 mkdir $SCRIPT_DIR/repos
-helm pull oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/rasa --version 2.0.5 --untar --destination $SCRIPT_DIR/repos/rasa-helm
+helm pull oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/rasa --version 2.0.6 --untar --destination $SCRIPT_DIR/repos/rasa-helm
 
 print_info "Getting storage account key..."
 SAKEYS_OUTPUT_OUTPUT=$(az storage account keys list \

--- a/azure/rasa/assistant/values.template.yaml
+++ b/azure/rasa/assistant/values.template.yaml
@@ -6,7 +6,6 @@ rasa:
     environment: production
     enableApi: true
     credentials:
-      enabled: true
       socketio:
         bot_message_evt: bot_uttered
         metadata_key: customData
@@ -27,7 +26,6 @@ rasa:
           provider: openai
       # Configure the assistant to use our PostgreSQL instance as the Tracker Store, which records the assistant's conversations.
       tracker_store:
-        enabled: true
         type: sql
         dialect: postgresql
         url: ${DB_HOST}
@@ -38,7 +36,6 @@ rasa:
       # Configure the assistant to use Redis as the Rasa Lock Store.
       # This is needed when you have a high-load scenario that requires the Rasa server to be replicated across multiple instances. It ensures that even with multiple servers, the messages for each conversation are handled in the correct sequence without any loss or overlap.
       lock_store:
-        enabled: true
         type: concurrent_redis
         password: ${REDIS_PASSWORD}
         port: 6380
@@ -47,7 +44,6 @@ rasa:
         key_prefix: ${NAME}
       # Configure the assistant to use the Kafka broker. This allows us to perform further processing on the messages, like using the Rasa Studio Conversation View or Rasa Pro Analytics.
       event_broker:
-        enabled: true
         type: kafka
         security_protocol: SASL_PLAINTEXT
         sasl_mechanism: SCRAM-SHA-512

--- a/gcp/rasa/assistant/setup-assistant.sh
+++ b/gcp/rasa/assistant/setup-assistant.sh
@@ -22,7 +22,7 @@ kubectl get ns
 # This Helm chart contains instructions for setting up the Rasa bot and Analytics components.
 print_info "Pulling Rasa Helm chart..."
 mkdir $SCRIPT_DIR/repos
-helm pull oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/rasa --version 2.0.5 --untar --destination $SCRIPT_DIR/repos/rasa-helm
+helm pull oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/rasa --version 2.0.6 --untar --destination $SCRIPT_DIR/repos/rasa-helm
 
 # Next, we'll ensure that other passwords and secret values that Rasa requires are set, before creating a Kubernetes Secret to securely store them in a way that we can reference later on:
 print_info "Creating secrets for the Rasa assistant to use..."

--- a/gcp/rasa/assistant/values.template.yaml
+++ b/gcp/rasa/assistant/values.template.yaml
@@ -12,7 +12,6 @@ rasa:
   settings:
     enableApi: true
     credentials:
-      enabled: true
       socketio:
         bot_message_evt: bot_uttered
         metadata_key: customData
@@ -33,7 +32,6 @@ rasa:
           provider: openai
       # Configure the assistant to use our PostgreSQL instance as the Tracker Store, which records the assistant's conversations.
       tracker_store:
-        enabled: true
         type: sql
         dialect: postgresql
         url: ${DB_HOST}
@@ -44,7 +42,6 @@ rasa:
       # Configure the assistant to use Redis as the Rasa Lock Store.
       # This is needed when you have a high-load scenario that requires the Rasa server to be replicated across multiple instances. It ensures that even with multiple servers, the messages for each conversation are handled in the correct sequence without any loss or overlap.
       lock_store:
-        enabled: true
         type: concurrent_redis
         password: ${REDIS_PASSWORD}
         port: 6379
@@ -53,7 +50,6 @@ rasa:
         key_prefix: ${NAME}
       # Configure the assistant to use the Kafka broker. This allows us to perform further processing on the messages, like using the Rasa Studio Conversation View or Rasa Pro Analytics.
       event_broker:
-        enabled: true
         type: kafka
         security_protocol: SASL_PLAINTEXT
         sasl_mechanism: PLAIN


### PR DESCRIPTION
Fixes issues found while deploying Rasa Pro 3.17 on AWS with Helm chart 2.0.6:

- RDS engine version — Replace hardcoded 17.4 with RDS_POSTGRES_ENGINE_VERSION (default 17.10) so deployments work in regions where that minor version isn’t available.
- Helm values schema — Remove nested enabled: true flags from credentials, tracker_store, lock_store, and event_broker in AWS/Azure/GCP values.template.yaml files (not valid under chart 2.0.6).
- external-dns install — Update only the external-dns Helm repo instead of running a full helm repo update, avoiding failures when other repos (e.g. Bitnami/Kafka) are unreachable.